### PR TITLE
Improve tracker name detection

### DIFF
--- a/libtc/clients/qbittorrent.py
+++ b/libtc/clients/qbittorrent.py
@@ -9,7 +9,11 @@ from ..baseclient import BaseClient
 from ..bencode import bencode
 from ..exceptions import FailedToExecuteException
 from ..torrent import TorrentData, TorrentFile, TorrentState
-from ..utils import calculate_minimum_expected_data, has_minimum_expected_data
+from ..utils import (
+    calculate_minimum_expected_data,
+    get_tracker_domain,
+    has_minimum_expected_data,
+)
 
 
 class QBittorrentClient(BaseClient):
@@ -70,7 +74,7 @@ class QBittorrentClient(BaseClient):
 
             tracker = ""
             if torrent["tracker"]:
-                tracker = ".".join(torrent["tracker"].split("/")[2].rsplit(".", 2)[1:])
+                tracker = get_tracker_domain(torrent["tracker"])
 
             result.append(
                 TorrentData(

--- a/libtc/clients/rtorrent.py
+++ b/libtc/clients/rtorrent.py
@@ -16,6 +16,7 @@ from ..scgitransport import SCGITransport
 from ..torrent import TorrentData, TorrentFile, TorrentState
 from ..utils import (
     calculate_minimum_expected_data,
+    get_tracker_domain,
     has_minimum_expected_data,
     map_existing_files,
 )
@@ -95,7 +96,7 @@ class RTorrentClient(BaseClient):
 
             progress = (torrent[5] / torrent[4]) * 100
             if torrent[10]:
-                tracker = ".".join(torrent[10][0][0].split("/")[2].rsplit(".", 2)[1:])
+                tracker = get_tracker_domain(torrent[10][0][0])
             else:
                 tracker = "None"
 

--- a/libtc/clients/transmission.py
+++ b/libtc/clients/transmission.py
@@ -13,7 +13,11 @@ from ..baseclient import BaseClient
 from ..bencode import bencode
 from ..exceptions import FailedToExecuteException
 from ..torrent import TorrentData, TorrentFile, TorrentState
-from ..utils import calculate_minimum_expected_data, has_minimum_expected_data
+from ..utils import (
+    calculate_minimum_expected_data,
+    get_tracker_domain,
+    has_minimum_expected_data,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -83,9 +87,7 @@ class TransmissionClient(BaseClient):
                 state = TorrentState.STOPPED
 
             if torrent["trackers"]:
-                tracker = ".".join(
-                    torrent["trackers"][0]["announce"].split("/")[2].rsplit(".", 2)[1:]
-                )
+                tracker = get_tracker_domain(torrent["trackers"][0]["announce"])
             else:
                 tracker = "None"
 

--- a/libtc/utils.py
+++ b/libtc/utils.py
@@ -1,5 +1,8 @@
 import os
 from pathlib import Path
+from urllib.parse import urlparse
+
+import publicsuffixlist
 
 
 def is_legal_path(path):
@@ -72,3 +75,12 @@ def has_minimum_expected_data(expected_data, actual_data):
     elif expected_data == actual_data == "full":
         return True
     return False
+
+
+def get_tracker_domain(tracker):
+    url = urlparse(tracker)
+    return get_tracker_domain.psl.privatesuffix(url.hostname)
+
+
+# Takes significant time to instantiate (~100ms), so only do it once
+get_tracker_domain.psl = publicsuffixlist.PublicSuffixList()

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "requests~=2.23.0",
         "click~=7.1.2",
         "tabulate~=0.8.7",
+        "publicsuffixlist~=0.7.3",
     ],
     tests_require=["pytest",],
     extras_require={"liltorrent": ["Flask~=1.1.2", "waitress~=1.4.3"]},

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,3 +5,4 @@ pytest~=5.4.2
 Flask~=1.1.2
 waitress~=1.4.3
 click~=7.1.2
+publicsuffixlist~=0.7.3


### PR DESCRIPTION
Some trackers use the top domain for the tracker host name. In such
cases, the previous approach would leave only the TLD: for example, if
the tracker host name was 'example.com', libtc would report the tracker
as just 'com'.

Unlike a more naive approach of ensuring the tracker contains at least
two components, this one will work correctly even for ccSLDs (such as
.co.uk).

Also break out the code into a separate function.